### PR TITLE
Fix manage_file_capabilities

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -52,7 +52,7 @@ class vault::install {
     }
 
     if $::vault::install_method == 'repo' {
-      Package['vault'] ~> File_capability['vault_binary_capability']
+      Package[$::vault::package_name] ~> File_capability['vault_binary_capability']
     }
   }
 


### PR DESCRIPTION
##### SUMMARY
Fixes a bug where manage_file_capabilities is true and $::vault::package_name is custom name (not 'vault')

##### TESTS/SPECS

I would like to add a spec test for this, but I would need to host a repository with a different package name. If anyone has a suggestions on how to mock that? 
Rest would be smth like:

```
        context 'when installed from package repository with managed_capability' do
          let(:params) do
            {
              install_method: 'repo',
              package_name: 'vault-private',
              package_ensure: 'installed',
              manage_file_capabilities: true
            }
          end

          it { is_expected.to contain_package('vault') }
          it { is_expected.to contain_file_capability('vault_binary_capability') }
```